### PR TITLE
Let Engine return its Vertx, more tests for coverage

### DIFF
--- a/src/main/java/com/redhat/vertx/Engine.java
+++ b/src/main/java/com/redhat/vertx/Engine.java
@@ -14,6 +14,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.eventbus.EventBus;
 import io.vertx.reactivex.core.eventbus.MessageConsumer;
 
@@ -44,6 +45,10 @@ public class Engine extends AbstractVerticle {
 
     public EventBus getEventBus() {
         return vertx.eventBus();
+    }
+
+    public Vertx getVertRx() {
+        return vertx;
     }
 
     @Override

--- a/src/main/java/io/burt/jmespath/vertx/VertxRuntime.java
+++ b/src/main/java/io/burt/jmespath/vertx/VertxRuntime.java
@@ -111,16 +111,22 @@ public class VertxRuntime extends JcfRuntime {
      */
     @Override
     public boolean isTruthy(Object value) {
-        if (value instanceof Boolean) {
-            return (Boolean)value;
-        } else if (value instanceof JsonArray) {
-            return ((JsonArray)value).size() > 0;
-        } else if (value instanceof JsonObject) {
-            return ((JsonObject)value).size() > 0;
-        } else if (value instanceof String) {
-            return ((String)value).length() > 0;
+        switch (typeOf(value)) {
+            case BOOLEAN:
+                return (Boolean)value;
+            case ARRAY:
+                return ((JsonArray)value).size() > 0;
+            case OBJECT:
+                return ((JsonObject)value).size() > 0;
+            case STRING:
+                return ((String)value).length() > 0;
+            case NULL:
+                return false;
+            case NUMBER:
+                return true;
+            default:
+                throw new IllegalStateException();
         }
-        return value != null;
     }
 
     @Override

--- a/src/test/java/io/burt/jmespath/vertx/VertxTest.java
+++ b/src/test/java/io/burt/jmespath/vertx/VertxTest.java
@@ -4,7 +4,6 @@ import io.burt.jmespath.JmesPathRuntimeTest;
 import io.burt.jmespath.JmesPathType;
 import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.Adapter;
-import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.junit.Test;
 

--- a/src/test/java/io/burt/jmespath/vertx/VertxTest.java
+++ b/src/test/java/io/burt/jmespath/vertx/VertxTest.java
@@ -1,12 +1,67 @@
 package io.burt.jmespath.vertx;
 
-import io.vertx.core.json.JsonObject;
-
 import io.burt.jmespath.JmesPathRuntimeTest;
 import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.Adapter;
+import org.junit.Test;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VertxTest extends JmesPathRuntimeTest<Object> {
   @Override
   protected Adapter<Object> createRuntime(RuntimeConfiguration configuration) { return new VertxRuntime(configuration); }
+
+    @Test
+    public void testLists() throws NoSuchAlgorithmException {
+        byte[] bytes = new byte[20];
+        SecureRandom.getInstanceStrong().nextBytes(bytes);
+        String bytesString = Base64.getEncoder().encodeToString(bytes);
+
+        var map = new HashMap<String, Object>();
+        map.put("text","hi");
+
+        var backingArr = Arrays.asList(
+                    1L,                                        // 0
+                    1f,                                        // 1
+                    1,                                         // 2
+                    1.2,                                       // 3
+                    bytesString,                               // 4
+                    "",                                        // 5
+                    true,                                      // 6
+                    Instant.parse("2019-08-19T14:15:00.000Z"), // 7
+                    Arrays.asList(new Object[]{"hi"}),         // 8
+                    map,                                       // 9
+                    new StringBuffer("testing"),               // 10
+                    null                                       // 11
+        );
+
+        var runtime = createRuntime(RuntimeConfiguration.defaultConfiguration());
+        var newList = runtime.toList(runtime.createArray(backingArr));
+
+        assertThat(newList).isNotEqualTo(backingArr);
+        assertThat(newList.get(0)).isEqualTo(1L);
+        assertThat(newList.get(1)).isEqualTo(1f);
+        assertThat(newList.get(2)).isEqualTo(1);
+        assertThat(newList.get(3)).isEqualTo(1.2);
+        assertThat(newList.get(4)).isEqualTo(bytesString);
+        assertThat(newList.get(5)).isEqualTo("");
+        assertThat(newList.get(6)).isEqualTo(true);
+        assertThat(newList.get(7)).isEqualTo(Instant.parse("2019-08-19T14:15:00.000Z").toString());
+        assertThat(runtime.toList(newList.get(8))).isEqualTo(backingArr.get(8));
+        assertThat(parseObject(runtime,(newList.get(9)))).isEqualTo(backingArr.get(9));
+        assertThat(newList.get(10)).isNotNull();
+        assertThat(newList.get(11)).isNull();
+    }
+
+    private Map<String,Object> parseObject(Adapter<Object> runtime, Object obj) {
+      var map = new HashMap<String,Object>();
+      runtime.getPropertyNames(obj).iterator().forEachRemaining(p -> map.put((String)p,runtime.getProperty(obj,p)));
+      return Collections.unmodifiableMap(map);
+    }
+  
 }


### PR DESCRIPTION
Engine is a Verticle which means it has a getVertx() method, which is lovely, but it's not the reactive vertx you get back.  The Verticle has protected access to the reactive vertx, and this shares that.

Also I cribbed your tests to run through some of the paces for the Vert.X Jmespath Runtime, but I'm not seeing any change in coverage on my local even though I know it's running several lines that coverage says aren't covered, so I want to see if it somehow executes/renders differently here. 