### PR TITLE
Allow Step.init() to be async

### DIFF
--- a/src/main/java/com/redhat/vertx/Engine.java
+++ b/src/main/java/com/redhat/vertx/Engine.java
@@ -34,6 +34,7 @@ public class Engine extends AbstractVerticle {
     private JsonObject systemConfig;
     private Map<String, JsonObject> docCache = new ConcurrentHashMap<>();
     private JinjaTemplateProcessor templateProcessor;
+    private Completable initComplete;
 
     public Engine(String pipelineDef) {
         this(pipelineDef, new JsonObject());
@@ -51,7 +52,7 @@ public class Engine extends AbstractVerticle {
             jo = (JsonObject)json;
         }
         this.pipeline = new Section();
-        pipeline.init(this,jo);
+        initComplete = pipeline.init(this,jo);
     }
 
     public EventBus getEventBus() {
@@ -87,7 +88,7 @@ public class Engine extends AbstractVerticle {
                     emitter.onComplete();
                 }
             }); // TODO dispose properly
-        });
+        }).mergeWith(initComplete);
     }
 
     /**

--- a/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
+++ b/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
@@ -24,7 +24,7 @@ public abstract class AbstractStep extends DocBasedDisposableManager implements 
     private boolean initialized;
 
     @Override
-    public void init(Engine engine, JsonObject config) {
+    public Completable init(Engine engine, JsonObject config) {
         assert !initialized;
         this.engine = engine;
         name = config.getString("name");
@@ -32,6 +32,7 @@ public abstract class AbstractStep extends DocBasedDisposableManager implements 
         timeout = config.getLong("timeout_ms", 5000L);
         registerTo = config.getString("register");
         initialized = true;
+        return Completable.complete();
     }
 
     /**

--- a/src/main/java/com/redhat/vertx/pipeline/Section.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Section.java
@@ -40,16 +40,18 @@ public class Section extends DocBasedDisposableManager implements Step {
     }
 
     @Override
-    public void init(Engine engine, JsonObject config) {
+    public Completable init(Engine engine, JsonObject config) {
         this.engine = engine;
         this.name = config.getString("name","default");
+        List<Completable> stepCompletables = new ArrayList<>();
         List<Step> steps = new ArrayList<>();
-        for (Object stepConfig : config.getJsonArray("steps", new JsonArray())) {
+        config.getJsonArray("steps", new JsonArray()).forEach( stepConfig -> {
             Step s = buildStep((JsonObject)stepConfig);
-            s.init(engine,(JsonObject)stepConfig);
+            stepCompletables.add(s.init(engine,(JsonObject)stepConfig));
             steps.add(s);
-        }
+        });
         this.steps=Collections.unmodifiableList(steps);
+        return Completable.merge(stepCompletables);
     }
 
     public Maybe<JsonObject> execute(String uuid) {

--- a/src/main/java/com/redhat/vertx/pipeline/Step.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Step.java
@@ -1,6 +1,7 @@
 package com.redhat.vertx.pipeline;
 
 import com.redhat.vertx.Engine;
+import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.vertx.core.json.JsonObject;
 
@@ -22,7 +23,7 @@ public interface Step {
      * @param engine The engine to which this step is bound.  The engine provides document cache and vertx.
      * @param config The configuration for this step
      */
-    public void init(Engine engine, JsonObject config);
+    public Completable init(Engine engine, JsonObject config);
 
     /**
      *

--- a/src/test/java/com/redhat/vertx/pipeline/step/AbstractStepTest.java
+++ b/src/test/java/com/redhat/vertx/pipeline/step/AbstractStepTest.java
@@ -26,11 +26,6 @@ public class AbstractStepTest {
         Logger logger = Logger.getLogger(this.getClass().getName());
 
         @Override
-        public void init(Engine engine, JsonObject config) {
-            super.init(engine, config);
-        }
-
-        @Override
         public Object execute(JsonObject doc) throws StepDependencyNotMetException {
             String base = doc.getString("from");
             if (base==null) {

--- a/src/test/java/com/redhat/vertx/pipeline/step/HelloWorldStep.java
+++ b/src/test/java/com/redhat/vertx/pipeline/step/HelloWorldStep.java
@@ -2,19 +2,26 @@ package com.redhat.vertx.pipeline.step;
 
 import com.redhat.vertx.Engine;
 import com.redhat.vertx.pipeline.Step;
+import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.vertx.core.json.JsonObject;
 import org.kohsuke.MetaInfServices;
 
+/**
+ * This implements a basic greeting in a minimal step.  Most steps should not start here, but
+ * rather extend {@link com.redhat.vertx.pipeline.AbstractStep} which will provide context and,
+ * for steps that aren't blocking, abstract away the reactive element.
+ */
 @MetaInfServices(Step.class)
 public class HelloWorldStep implements Step {
     private String name;
     private String registerTo;
 
     @Override
-    public void init(Engine engine, JsonObject config) {
+    public Completable init(Engine engine, JsonObject config) {
         name = config.getJsonObject("vars",new JsonObject()).getString("name","world");
         registerTo = config.getString("register","greeting");
+        return Completable.complete();
     }
 
     @Override


### PR DESCRIPTION
If some I/O were required in Step.init, or some other long operation, it will need a Completable so that it can announce when it's finished.  This allows that.