### PR TITLE
more tests, comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <version>${vertx.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
+++ b/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
@@ -6,7 +6,6 @@ import java.util.logging.Logger;
 
 import com.redhat.vertx.Engine;
 import com.redhat.vertx.pipeline.json.TemplatedJsonObject;
-import com.redhat.vertx.pipeline.templates.JinjaTemplateProcessor;
 import com.redhat.vertx.pipeline.templates.MissingParameterException;
 import io.reactivex.*;
 import io.reactivex.disposables.Disposable;

--- a/src/main/java/com/redhat/vertx/pipeline/templates/MissingParameterException.java
+++ b/src/main/java/com/redhat/vertx/pipeline/templates/MissingParameterException.java
@@ -2,6 +2,7 @@ package com.redhat.vertx.pipeline.templates;
 
 /**
  * A parameter is required from the environment but not found.
+ * Thrown by a {@link TemplateProcessor} when things go wrong.
  */
 public class MissingParameterException extends RuntimeException {
     public MissingParameterException() { }

--- a/src/main/java/com/redhat/vertx/pipeline/templates/TemplateProcessor.java
+++ b/src/main/java/com/redhat/vertx/pipeline/templates/TemplateProcessor.java
@@ -5,5 +5,11 @@ import io.vertx.core.json.JsonObject;
 import java.util.Map;
 
 public interface TemplateProcessor {
+    /**
+     * @param env The environment from which to look up variables
+     * @param str The string to which to apply the template
+     * @throws MissingParameterException if a variable mentioned in the string cannot be found in the environment.
+     * @return An unmodified string if it contains no template markup, or the modified string with template applied
+     */
     public String applyTemplate(Map<String,Object> env, String str);
 }

--- a/src/test/java/com/redhat/vertx/pipeline/templates/TemplatedJsonObjectTest.java
+++ b/src/test/java/com/redhat/vertx/pipeline/templates/TemplatedJsonObjectTest.java
@@ -1,0 +1,22 @@
+package com.redhat.vertx.pipeline.templates;
+
+import com.redhat.vertx.pipeline.json.TemplatedJsonObject;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TemplatedJsonObjectTest {
+    @Test
+    public void testTemplatedJsonObject() {
+        JsonObject doc = new JsonObject();
+        doc.put("boat","{{untouched}}");
+
+        JsonObject data = new JsonObject();
+        data.put("doc",doc);
+        data.put("q","{{there}}");
+        data.put("there","{{doc.boat}}");
+        TemplatedJsonObject tjo = new TemplatedJsonObject(data, new JinjaTemplateProcessor(), "doc");
+        assertThat(tjo.getValue("q")).isEqualTo("{{untouched}}");
+    }
+}


### PR DESCRIPTION
I was going to add an explicit catch around executeSlow, but it turned out to be unnecessary because the code that actually calls [`AbstractStep.execute0()`](https://github.com/ke4roh/vertx-engine/blob/master/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java#L55) is smart enough to put the exception on the resulting `Maybe`.  Here's the test showing that, and there's a test showing deep resolution of templates.  