### PR TITLE
WIP: Section finishes when all remaining work is done

### DIFF
--- a/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
+++ b/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
@@ -1,7 +1,6 @@
 package com.redhat.vertx.pipeline;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import com.redhat.vertx.Engine;
@@ -38,82 +37,44 @@ public abstract class AbstractStep extends DocBasedDisposableManager implements 
     /**
      * Responsibilities:
      * <ul>
-     *     <li>Execute its step</li>
-     *     <li>Defer the step whose dependencies are not met</li>
-     *     <li>Retry the step whose dependencies are not met when a change happens</li>
-     *     <li>Fetch the document from the engine</li>
+     *     <li>Call {@link #executeSlow(JsonObject)} with the appropriate environment</li>
+     *     <li>Wrap the result from {@link #executeSlow(JsonObject)} in a JsonObject</li>
      * </ul>
      *
-     * @param uuid the key for the document being built (get it from the engine)
+     * @param docId the key for the document being built (get it from the engine)
      * @return a Maybe containing a JsonObject with one entry, the key equal to the "register" config object,
      * or simply complete if the step has executed without returning a value.
      */
     @Override
-    public final Maybe<JsonObject> execute(String uuid) {
+    public final Maybe<JsonObject> execute(String docId) {
         assert initialized;
-        return Maybe.create(source -> execute0(uuid, source, new ArrayList<>(2)) );
-    }
-
-    /**
-     * @param uuid   The UUID of the document to be operated on
-     * @param source The SingleEmitter for the AbstractStep execution we're attmembempting to complete
-     */
-    private void execute0(String uuid, MaybeEmitter<JsonObject> source, List<Disposable> listener) {
-        /*
-         * The gist of this function is:
-         *
-         * try {
-         *    executeSlow(success -> pass it back,
-         *    error -> if it was StepDependencyNotMetException and we don't already have a listener, register a listener
-         *    and try again.)
-         *
-         * } catch (StepDependencyNotMetException e) {
-         *    register a listener and defer execution until after a change
-         * }
-         */
-        Maybe<Object> result = executeSlow(getEnvironment(uuid));
-        addDisposable(uuid,result
-                .timeout(timeout, TimeUnit.MILLISECONDS)
-                .subscribe(resultReturn -> {
-                    logger.finest(() -> "Step " + name + " returned: " + resultReturn.toString());
-                    listener.forEach(Disposable::dispose);
-                    logger.finest(() -> "Removing from listener " + System.identityHashCode(listener) + " size=" +
-                            listener.size() + " disposables for step " + name + ".");
-                    listener.clear();
-                    if (registerTo != null) {
-                        source.onSuccess(new JsonObject().put(registerTo,resultReturn));
-                    } else {
+        JsonObject env = getEnvironment(docId);
+        return Maybe.create(source -> addDisposable(docId,executeSlow(env).subscribe(
+                rval -> {
+                    if (registerTo == null) {
                         source.onComplete();
+                    } else {
+                        source.onSuccess(new JsonObject().put(registerTo, rval));
                     }
                 },
-                err -> {
-                    if (err instanceof StepDependencyNotMetException || err instanceof MissingParameterException) {
-                        if (listener.isEmpty()) {
-                            logger.finest(() -> "Step " + name + " listening for a change.");
-                            listener.add(engine.getEventBus()
-                                    .consumer(EventBusMessage.DOCUMENT_CHANGED).toObservable()
-                                    .filter(msg -> uuid.equals(msg.headers().get("uuid")))
-                                    .subscribe(msg -> execute0(uuid, source, listener)));
-                        }
-                    } else if (err != null) {
-                        source.tryOnError(err);
-                    }
-                }));
+                source::onError,
+                source::onComplete
+        )));
     }
 
-    protected JsonObject getEnvironment(String uuid) {
+    protected JsonObject getEnvironment(String docId) {
          JsonObject vars = this.vars.copy();
-         vars.put("doc",getDocument(uuid));
+         vars.put("doc",getDocument(docId));
          vars.put("system", engine.getSystemConfig());
          return new TemplatedJsonObject(vars,engine.getTemplateProcessor(),"doc", "system");
     }
 
     /**
-     * @param uuid The UUID of the document under construction
+     * @param docId The UUID of the document under construction
      * @return The document (without local step variables) from the engine, based on the given UUID
      */
-    protected JsonObject getDocument(String uuid) {
-        return engine.getDocument(uuid);
+    protected JsonObject getDocument(String docId) {
+        return engine.getDocument(docId);
     }
 
     /**

--- a/src/main/java/com/redhat/vertx/pipeline/DocBasedDisposableManager.java
+++ b/src/main/java/com/redhat/vertx/pipeline/DocBasedDisposableManager.java
@@ -1,11 +1,10 @@
 package com.redhat.vertx.pipeline;
 
-import io.reactivex.Completable;
 import io.reactivex.disposables.Disposable;
 
 import java.util.*;
 
-public abstract class DocBasedDisposableManager implements Step {
+public abstract class DocBasedDisposableManager {
     private Map<String, Collection<Disposable>> disposables = new HashMap<>();
 
 
@@ -19,7 +18,6 @@ public abstract class DocBasedDisposableManager implements Step {
         d.addAll(disposables);
     }
 
-    @Override
     public void finish(String uuid) {
         Collection<Disposable> doomed = disposables.remove(uuid);
         if (doomed != null) {

--- a/src/test/java/com/redhat/vertx/pipeline/IncompletePipelineTest.java
+++ b/src/test/java/com/redhat/vertx/pipeline/IncompletePipelineTest.java
@@ -1,0 +1,31 @@
+package com.redhat.vertx.pipeline;
+
+import com.redhat.ResourceUtils;
+import com.redhat.vertx.Engine;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class IncompletePipelineTest {
+    @Test
+    public void testIncompletePipeline(Vertx vertx, VertxTestContext testContext) throws Exception {
+        Engine e = new Engine(ResourceUtils.fileContentsFromResource("com/redhat/vertx/pipeline/incomplete-pipeline-test.yaml"));
+        vertx.rxDeployVerticle(e).blockingGet();
+        JsonObject inputDoc = new JsonObject().put("q","foo");
+        JsonObject newDoc = e.execute(inputDoc).timeout(1, TimeUnit.SECONDS).blockingGet();
+        assertThat(newDoc.getString("q")).isEqualTo("foo");
+        assertThat(newDoc.getString("r")).isEqualTo("foo");
+        assertThat(newDoc.containsKey("absent")).isFalse();
+        assertThat(newDoc.containsKey("x")).isFalse();
+        testContext.completeNow();
+
+    }
+}

--- a/src/test/resources/com/redhat/vertx/pipeline/incomplete-pipeline-test.yaml
+++ b/src/test/resources/com/redhat/vertx/pipeline/incomplete-pipeline-test.yaml
@@ -1,0 +1,11 @@
+---
+- name: Copy a thing
+  class: com.redhat.vertx.pipeline.steps.Copy
+  vars:
+    from: "{{doc.q}}"
+  register: r
+- name: Copy something else
+  class: com.redhat.vertx.pipeline.steps.Copy
+  vars:
+    from: "{{doc.absent}}"
+  register: x


### PR DESCRIPTION
This revamps the process for executing steps and finishing when all the work is done.  It is less than fastest (because it goes in batches of steps that can be executed rather than retrying every blocked step at the completion of any step), but that tradeoff seems to have made it more readable at least.  It could be worth revisiting later to make it be more proactive, particularly for the case of long-running interdependencies.