### PR TITLE
DSL Clean-up patch

### DIFF
--- a/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
+++ b/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
@@ -1,6 +1,7 @@
 package com.redhat.vertx.pipeline;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -16,10 +17,10 @@ import io.vertx.reactivex.core.Vertx;
  */
 public abstract class AbstractStep implements Step {
     protected Logger logger = Logger.getLogger(this.getClass().getName());
-    protected JsonObject vars;
     protected Engine engine;
     protected String name;
     protected Vertx vertx;
+    private JsonObject vars;
     private JsonObject stepConfig;
     private Duration timeout;
     private String registerTo;
@@ -30,11 +31,15 @@ public abstract class AbstractStep implements Step {
         assert !initialized;
         this.engine = engine;
         name = config.getString("name");
-        stepConfig = config.getJsonObject(getShortName(), new JsonObject());
+        stepConfig = config.getJsonObject(getShortName());
 
-        vars = stepConfig.getJsonObject("vars", new JsonObject());
+        // Just in case there isn't any additional config for a step
+        stepConfig = Objects.isNull(stepConfig) ? new JsonObject() : stepConfig;
+
+        vars = stepConfig; // This is typically correct
+
         timeout = Duration.parse(config.getString("timeout", "PT5.000S"));
-        registerTo = stepConfig.getString("register");
+        registerTo = config.getString("register");
         initialized = true;
         return Completable.complete();
     }
@@ -116,5 +121,10 @@ public abstract class AbstractStep implements Step {
     @Override
     public JsonObject getStepConfig() {
         return this.stepConfig;
+    }
+
+    @Override
+    public JsonObject getVars() {
+        return this.vars;
     }
 }

--- a/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
+++ b/src/main/java/com/redhat/vertx/pipeline/AbstractStep.java
@@ -76,7 +76,7 @@ public abstract class AbstractStep implements Step {
         vars.put("system", engine.getSystemConfig());
 
         JsonObject stepAsJson = new JsonObject();
-        stepAsJson.put("name", this.name);
+        stepAsJson.put("name", this.getName());
         stepAsJson.put("shortName", this.getShortName());
         stepAsJson.put("register", this.registerTo);
         stepAsJson.put("timeout", this.timeout.toString());

--- a/src/main/java/com/redhat/vertx/pipeline/Section.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Section.java
@@ -89,7 +89,7 @@ public class Section implements Step {
     }
 
     @Override
-    public JsonObject getStepConfig() {
+    public JsonObject getConfig() {
         return this.stepConfig;
     }
 

--- a/src/main/java/com/redhat/vertx/pipeline/Section.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Section.java
@@ -39,7 +39,7 @@ public class Section implements Step {
                         Optional::of));
 
         // Get all the config keys, strip out reserved words
-        final var defKeys = def.getMap().keySet();
+        final var defKeys = new HashSet<>(def.getMap().keySet());
         defKeys.removeAll(RESERVED_WORDS);
 
         // We had more than the short name of the step, error
@@ -90,7 +90,12 @@ public class Section implements Step {
 
     @Override
     public JsonObject getStepConfig() {
-        return new JsonObject();
+        return this.stepConfig;
+    }
+
+    @Override
+    public JsonObject getVars() {
+        return this.stepConfig;
     }
 
     private void publishSectionEvent(String documentId, String message) {

--- a/src/main/java/com/redhat/vertx/pipeline/Step.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Step.java
@@ -59,7 +59,7 @@ public interface Step {
     /**
      * @return Configuration for the step as defined in the pipeline
      */
-    JsonObject getStepConfig();
+    JsonObject getConfig();
 
     /**
      * @return Variables for the step from pipeline configuration

--- a/src/main/java/com/redhat/vertx/pipeline/Step.java
+++ b/src/main/java/com/redhat/vertx/pipeline/Step.java
@@ -60,4 +60,9 @@ public interface Step {
      * @return Configuration for the step as defined in the pipeline
      */
     JsonObject getStepConfig();
+
+    /**
+     * @return Variables for the step from pipeline configuration
+     */
+    JsonObject getVars();
 }

--- a/src/test/java/com/redhat/vertx/pipeline/step/AbstractStepTest.java
+++ b/src/test/java/com/redhat/vertx/pipeline/step/AbstractStepTest.java
@@ -127,4 +127,14 @@ public class AbstractStepTest {
                 () -> needExceptionFinishTest(null,null,testContext, TimeoutException.class) );
 
     }
+
+    @Test
+    public void testStepAsPartOfEnvironment(Vertx vertx, VertxTestContext testContext) {
+        Engine e = new Engine(ResourceUtils.fileContentsFromResource("com/redhat/vertx/pipeline/step/step-part-of-env.yml"));
+        vertx.rxDeployVerticle(e).blockingGet();
+        JsonObject inputDoc = new JsonObject().put("x","");
+        JsonObject newDoc = e.execute(inputDoc).timeout(1, TimeUnit.SECONDS).blockingGet();
+        assertThat(newDoc.getString("hello")).isEqualTo("Hello from the \"step name check\" step");
+        testContext.completeNow();
+    }
 }

--- a/src/test/java/com/redhat/vertx/pipeline/step/HelloWorldStep.java
+++ b/src/test/java/com/redhat/vertx/pipeline/step/HelloWorldStep.java
@@ -1,9 +1,9 @@
 package com.redhat.vertx.pipeline.step;
 
 import com.redhat.vertx.Engine;
+import com.redhat.vertx.pipeline.AbstractStep;
 import com.redhat.vertx.pipeline.Step;
 import io.reactivex.Completable;
-import io.reactivex.Maybe;
 import io.vertx.core.json.JsonObject;
 import org.kohsuke.MetaInfServices;
 
@@ -13,7 +13,7 @@ import org.kohsuke.MetaInfServices;
  * for steps that aren't blocking, abstract away the reactive element.
  */
 @MetaInfServices(Step.class)
-public class HelloWorldStep implements Step {
+public class HelloWorldStep extends AbstractStep {
     private String stepName;
     private String name;
     private String registerTo;
@@ -21,27 +21,14 @@ public class HelloWorldStep implements Step {
 
     @Override
     public Completable init(Engine engine, JsonObject config) {
-        stepName = config.getString("name","HelloWorld");
-        stepConfig = config.getJsonObject(getShortName(), new JsonObject());
-        var vars = stepConfig.getJsonObject("vars", new JsonObject());
-
-        name = vars.getString("name", "world");
-        registerTo = stepConfig.getString("register","greeting");
+        super.init(engine, config);
+        name = this.getVars().getString("name", "world");
+        registerTo = config.getString("register","greeting");
         return Completable.complete();
     }
 
     @Override
-    public Maybe<JsonObject> execute(String uuid) {
-        return Maybe.just(new JsonObject().put(registerTo,"hello, " + name));
-    }
-
-    @Override
-    public String getName() {
-        return stepName;
-    }
-
-    @Override
-    public JsonObject getStepConfig() {
-        return this.stepConfig;
+    public String execute(JsonObject env) {
+        return "hello, " + name;
     }
 }

--- a/src/test/resources/abstract-step-test-pipeline.json
+++ b/src/test/resources/abstract-step-test-pipeline.json
@@ -1,42 +1,34 @@
 [
   {
     "name": "m",
+    "register": "c",
     "concat": {
-      "vars": {
-        "from": "{{doc.x}}",
-        "append": "m"
-      },
-      "register": "c"
+      "from": "{{doc.x}}",
+      "append": "m"
     }
   },
   {
     "name": "e",
     "concat": {
-      "vars": {
-        "from": "{{doc.c}}",
-        "append": "e"
-      },
-      "register": "ca"
-    }
+      "from": "{{doc.c}}",
+      "append": "e"
+    },
+    "register": "ca"
   },
   {
     "name": "o",
     "concat": {
-      "vars": {
-        "from": "{{doc.ca}}",
-        "append": "o"
-      },
-      "register": "cat"
-    }
+      "from": "{{doc.ca}}",
+      "append": "o"
+    },
+    "register": "cat"
   },
   {
     "name": "w",
     "concat": {
-      "vars": {
-        "from": "{{doc.cat}}",
-        "append": "w"
-      },
-      "register": "cats"
-    }
+      "from": "{{doc.cat}}",
+      "append": "w"
+    },
+    "register": "cats"
   }
 ]

--- a/src/test/resources/com/redhat/vertx/pipeline/exception-in-step-pipeline-test.yaml
+++ b/src/test/resources/com/redhat/vertx/pipeline/exception-in-step-pipeline-test.yaml
@@ -1,4 +1,4 @@
 ---
 - name: FNFE
+  register: f
   f_n_f_e:
-    register: f

--- a/src/test/resources/com/redhat/vertx/pipeline/execute-prompt-really-is-prompt.yaml
+++ b/src/test/resources/com/redhat/vertx/pipeline/execute-prompt-really-is-prompt.yaml
@@ -1,18 +1,14 @@
 ---
 - name: Sleep - listed first, finish third
-  sleep:
-    vars: { duration: "PT1.0S" }
-    register: dolor
+  register: dolor
+  sleep: { duration: "PT1.0S" }
 - name: Copy - should finish first
-  copy:
-    vars: { from: "foo" }
-    register: Lorem
+  register: Lorem
+  copy: { from: "foo" }
 - name: Depend - should finish second
-  copy:
-    vars: { from: "{{doc.Lorem}}" }
-    register: ipsum
+  register: ipsum
+  copy: { from: "{{doc.Lorem}}" }
 - name: Depend on the sleep - should happen fourth/last
-  copy:
-    vars: { from: "{{doc.dolor}}" }
-    register: sit
+  register: sit
+  copy: { from: "{{doc.dolor}}" }
 

--- a/src/test/resources/com/redhat/vertx/pipeline/incomplete-pipeline-test.yaml
+++ b/src/test/resources/com/redhat/vertx/pipeline/incomplete-pipeline-test.yaml
@@ -1,11 +1,9 @@
 ---
 - name: Copy a thing
+  register: r
   copy:
-    vars:
-      from: "{{doc.q}}"
-    register: r
+    from: "{{doc.q}}"
 - name: Copy a missing field
+  register: x
   copy:
-    vars:
-      from: "{{doc.absent}}"
-    register: x
+    from: "{{doc.absent}}"

--- a/src/test/resources/com/redhat/vertx/pipeline/short-name-pipeline-unknown-key.yml
+++ b/src/test/resources/com/redhat/vertx/pipeline/short-name-pipeline-unknown-key.yml
@@ -1,5 +1,4 @@
 - name: Sleep - listed first, finish third
-  sleep:
-    vars: { duration: "PT1.0S" }
-    register: dolor
+  register: dolor
+  sleep: { duration: "PT1.0S" }
   foo:

--- a/src/test/resources/com/redhat/vertx/pipeline/short-name-pipeline.yml
+++ b/src/test/resources/com/redhat/vertx/pipeline/short-name-pipeline.yml
@@ -1,16 +1,12 @@
 - name: Sleep - listed first, finish third
-  sleep:
-    vars: { duration: "PT1.0S" }
-    register: dolor
+  register: dolor
+  sleep: { duration: "PT1.0S" }
 - name: Copy - should finish first
-  copy:
-    vars: { from: "foo" }
-    register: Lorem
+  register: Lorem
+  copy: { from: "foo" }
 - name: Depend - should finish second
-  copy:
-    vars: { from: "{{doc.Lorem}}" }
-    register: ipsum
+  register: ipsum
+  copy: { from: "{{doc.Lorem}}" }
 - name: Depend on the sleep - should happen fourth/last
-  copy:
-    vars: { from: "{{doc.dolor}}" }
-    register: sit
+  register: sit
+  copy: { from: "{{doc.dolor}}" }

--- a/src/test/resources/com/redhat/vertx/pipeline/step/step-part-of-env.yml
+++ b/src/test/resources/com/redhat/vertx/pipeline/step/step-part-of-env.yml
@@ -1,0 +1,5 @@
+---
+- name: step name check
+  register: hello
+  copy:
+    from: 'Hello from the "{{ step.name }}" step'

--- a/src/test/resources/com/redhat/vertx/pipeline/step/varSubstitutionTestPipeline.yaml
+++ b/src/test/resources/com/redhat/vertx/pipeline/step/varSubstitutionTestPipeline.yaml
@@ -1,15 +1,12 @@
 - name: tokenize
   copy:
-    register: words
-    vars:
-      from: '{{ doc.intro|split|tojson }}'
+    from: '{{ doc.intro|split|tojson }}'
+  register: words
 - name: first word
   copy:
-    register: first_word
-    vars:
-      from: '{{ doc.words[0] }}'
+    from: '{{ doc.words[0] }}'
+  register: first_word
 - name: fourth word
   copy:
-    register: fourth_word
-    vars:
-      from: '{{ doc.words[3] }}'
+    from: '{{ doc.words[3] }}'
+  register: fourth_word

--- a/src/test/resources/com/redhat/vertx/pipeline/unknown-step.yml
+++ b/src/test/resources/com/redhat/vertx/pipeline/unknown-step.yml
@@ -1,8 +1,6 @@
 - name: Sleep - listed first, finish third
-  foo:
-    vars: { duration: "PT1.0S" }
-    register: dolor
+  register: dolor
+  foo: { duration: "PT1.0S" }
 - name: Step two
-  foo:
-    vars: { duration: "PT1.0S" }
-    register: dolor
+  register: dolor
+  foo: { duration: "PT1.0S" }

--- a/src/test/resources/hello-world-many-steps-pipeline.json
+++ b/src/test/resources/hello-world-many-steps-pipeline.json
@@ -1,29 +1,23 @@
 [
   {
-    "name":"hello",
+    "name": "hello",
     "hello_world_step": {
-      "vars": {
-        "name": "Jason"
-      },
-      "register": "greetings"
-    }
+      "name": "Jason"
+    },
+    "register": "greetings"
   },
   {
-    "name":"knockKnock",
+    "name": "knockKnock",
     "hello_world_step": {
-      "vars": {
-        "name": "Banana"
-      },
-      "register": "nuisance"
-    }
+      "name": "Banana"
+    },
+    "register": "nuisance"
   },
   {
-    "name":"green",
+    "name": "green",
     "hello_world_step": {
-      "vars": {
-        "name": "Blue"
-      },
-      "register": "rainbow"
-    }
+      "name": "Blue"
+    },
+    "register": "rainbow"
   }
 ]

--- a/src/test/resources/hello-world-nested-sections-pipeline.json
+++ b/src/test/resources/hello-world-nested-sections-pipeline.json
@@ -1,34 +1,28 @@
 [
   {
-    "name":"hello",
+    "name": "hello",
     "hello_world_step": {
-      "vars": {
-        "name": "Jason"
-      },
-      "register": "greetings"
-    }
+      "name": "Jason"
+    },
+    "register": "greetings"
   },
   {
-    "name":"unusualGreetings",
+    "name": "unusualGreetings",
     "section": {
       "steps": [
         {
           "name": "knockKnock",
           "hello_world_step": {
-            "vars": {
-              "name": "Banana"
-            },
-            "register": "nuisance"
-          }
+            "name": "Banana"
+          },
+          "register": "nuisance"
         },
         {
           "name": "green",
           "hello_world_step": {
-            "vars": {
-              "name": "Blue"
-            },
-            "register": "rainbow"
-          }
+            "name": "Blue"
+          },
+          "register": "rainbow"
         }
       ]
     }

--- a/src/test/resources/hello-world-pipeline.json
+++ b/src/test/resources/hello-world-pipeline.json
@@ -1,11 +1,9 @@
 [
   {
-    "name":"hello",
+    "name": "hello",
     "hello_world_step": {
-      "vars": {
-        "name": "Jason"
-      },
-      "register": "greetings"
-    }
+      "name": "Jason"
+    },
+    "register": "greetings"
   }
 ]


### PR DESCRIPTION
Fixes #65
I've decided not to add register and timeout to the interface. 
Maybe we will later, not sure.

This adds a json view of a step so that jinjava can access it using the "step" keyword.
You should be able to access `{{ step.name }}`, `{{ step.shortName }}`, `{{ step.register }}`, `{{ step.timeout }}`, and `{{ step.variable_name }}` in jinjava now.